### PR TITLE
Don't accidentally build gamma tool when building a sketch

### DIFF
--- a/extras/gamma.c
+++ b/extras/gamma.c
@@ -1,3 +1,4 @@
+#ifndef ARDUINO
 // THIS IS NOT ARDUINO CODE -- DON'T INCLUDE IN YOUR SKETCH.  It's a
 // command-line tool that outputs a gamma correction table to stdout;
 // redirect or copy and paste the results into header file for the
@@ -49,3 +50,5 @@ int main(int argc, char *argv[])
 
 	return 0;
 }
+
+#endif /* !ARDUINO */


### PR DESCRIPTION
Some build systems are ~~lazy~~ efficient and will just try to build every source file they can find in the library folder. Let's do the same as [Adafruit-GFX](https://github.com/adafruit/Adafruit-GFX-Library/blob/master/fontconvert/fontconvert.c#L19) and not compile the tool code when building for Arduino, to avoid ending up with two main() methods.